### PR TITLE
Enhancements to BlinkHub Emitter & Updated Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,29 @@ To remove a listener from an event:
 unsubscribe(); // This will remove the callback from the event listeners.
 ```
 
+### The `once` Method
+
+The once method allows listeners to be invoked only once for the specified event. After the event has been emitted and the listener invoked, the listener is automatically removed. This can be useful for scenarios where you need to react to an event just a single time, rather than every time it's emitted.
+
+```typescript
+type UserEvents = {
+  userFirstLogin: (username: string) => void;
+};
+
+const userEmitter = new Emitter<UserEvents>();
+
+userEmitter.once('userFirstLogin', (username: string): void => {
+    console.log(`${username} has logged in for the first time!`);
+});
+
+userEmitter.emit('userFirstLogin', 'Alice'); // Outputs: Alice has logged in for the first time!
+userEmitter.emit('userFirstLogin', 'Alice'); // No output, as the listener has been removed.
+
+```
+
+#### Note:
+If an error occurs within a callback registered with `once`, the callback will not be re-invoked for subsequent events. Always handle errors adequately to prevent unforeseen behavior.
+
 ### Error Handling
 
 If an error occurs within a callback, the emitter will catch it and log it to the console. The emitter also pushes a null value to the results array in case of errors, though this behavior can be customized.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink-hub",
-  "version": "0.1.7",
+  "version": "0.2.0",
   "description": "A Dynamic Event Emitter for Modern Applications",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,24 @@ class Emitter<T extends Record<string, Callback<any[]>>> {
         };
     }
 
+    once<K extends keyof T>(name: K, callback: T[K], priority: number = 0): () => void {
+        let unsubscribe: (() => void) | null = null;
+
+        const wrappedCallback = (...args: Parameters<T[K]>): void => {
+            try {
+                callback(...args);
+            } finally {
+                if (unsubscribe) {
+                    unsubscribe();
+                }
+            }
+        };
+
+        unsubscribe = this.subscribe(name, wrappedCallback as any, priority);
+
+        return unsubscribe;
+    }
+
     emit<K extends keyof T>(name: K, ...args: Parameters<T[K]>): (ReturnType<T[K]> | Error)[] {
         if (!this.events[name]) {
             return [];

--- a/src/tests/subscribeOnce.test.ts
+++ b/src/tests/subscribeOnce.test.ts
@@ -1,0 +1,101 @@
+import Emitter from "../index";
+
+type MyEvents = {
+    sampleEvent: (msg: string) => void;
+};
+
+describe('Emitter .once() method', (): void => {
+    let emitter: Emitter<MyEvents>;
+
+    beforeEach(() => {
+        emitter = new Emitter<MyEvents>();
+    });
+
+    test('should execute the listener only once', (): void => {
+        let callCount: number = 0;
+        emitter.once('sampleEvent', (_: string): void => {
+            callCount++;
+        });
+
+        emitter.emit('sampleEvent', 'test');
+        emitter.emit('sampleEvent', 'test again');
+
+        expect(callCount).toBe(1);
+    });
+
+    test('should work with multiple listeners', (): void => {
+        let onceListenerCalled: boolean = false;
+        let regularListenerCalled: number = 0;
+
+        emitter.once('sampleEvent', (_: string): void => {
+            onceListenerCalled = true;
+        });
+
+        emitter.subscribe('sampleEvent', (_: string): void => {
+            regularListenerCalled++;
+        });
+
+        emitter.emit('sampleEvent', 'test');
+        emitter.emit('sampleEvent', 'test again');
+
+        expect(onceListenerCalled).toBe(true);
+        expect(regularListenerCalled).toBe(2);
+    });
+
+    test('should handle manual unsubscription', (): void => {
+        let callCount = 0;
+        const unsubscribe = emitter.once('sampleEvent', (_: string): void => {
+            callCount++;
+        });
+
+        unsubscribe();
+
+        emitter.emit('sampleEvent', 'test');
+
+        expect(callCount).toBe(0);
+    });
+
+    test('should pass arguments to the listener', (): void => {
+        let receivedMessage: string = '';
+
+        emitter.once('sampleEvent', (message): void => {
+            receivedMessage = message;
+        });
+
+        emitter.emit('sampleEvent', 'Hello!');
+
+        expect(receivedMessage).toBe('Hello!');
+    });
+
+    test('should respect priorities', (): void => {
+        let sequence: string[] = [];
+
+        emitter.once('sampleEvent', (_): void => {
+            sequence.push('high');
+        }, 10);
+
+        emitter.subscribe('sampleEvent', (_: string): void => {
+            sequence.push('low');
+        }, -10);
+
+        emitter.emit('sampleEvent', 'test');
+
+        expect(sequence).toEqual(['high', 'low']);
+    });
+
+    test('should handle errors and not re-invoke listener', (): void => {
+        let callCount: number = 0;
+
+        emitter.once('sampleEvent', (_): void => {
+            callCount++;
+            throw new Error("Test error");
+        });
+
+        const results1 = emitter.emit('sampleEvent', 'test');
+        const results2 = emitter.emit('sampleEvent', 'test again');
+
+        expect(results1[0]).toBeInstanceOf(Error);
+        expect(callCount).toBe(1);
+        expect(results2.length).toBe(0);
+    });
+});


### PR DESCRIPTION
Features:

once Method: Added the once method to the Emitter, allowing listeners to be automatically unsubscribed after being triggered once, making it ideal for scenarios where event reactions are required just once.

Documentation Updates:

The once Method Section: Expanded the section detailing the once method, with a clear example and an emphasis on its behavior regarding error occurrences.