### PR TITLE
Implement Event Channeling in Emitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,50 @@ emitter.emit('testEvent', 'some value');
 console.log(results);
 ```
 
-These are just simple examples to illustrate the type of scenarios where the <code>Emitter</code> can be used. Depending on your application, you can define more complex events and handlers to fit your needs...
+## Channel-Based Event Handling
+
+The Emitter also supports channel-based event handling, allowing for more granular control over event propagation and listener management.
+
+### Defining Channels
+
+Channels can be created to group specific event types or to separate event handling logic for different parts of an application:
+
+```typescript
+type ChannelEvents = {
+  channelEvent: (message: string) => void;
+};
+
+const emitter = new Emitter<ChannelEvents>();
+const chatChannel = emitter.channel('chat');
+const notificationChannel = emitter.channel('notification');
+```
+
+### Subscribing to Channel Events
+
+Listeners can subscribe to events within a specific channel, which is isolated from the global emitter and other channels:
+
+```typescript
+chatChannel.subscribe('channelEvent', (message: string) => {
+    console.log(`New chat message: ${message}`);
+});
+
+notificationChannel.subscribe('channelEvent', (message: string) => {
+    console.log(`New notification: ${message}`);
+});
+```
+
+### Emitting Channel Events
+
+Events can be emitted on specific channels without affecting listeners on other channels:
+
+```typescript
+chatChannel.emit('channelEvent', 'Hello, World!'); 
+// Outputs: New chat message: Hello, World!
+notificationChannel.emit('channelEvent', 'You have 3 new notifications!'); 
+// Outputs: New notification: You have 3 new notifications!
+```
+
+This channel-based approach ensures that events are handled only by the listeners that are relevant to the particular context or module, improving modularity and maintainability.
 
 ## FAQ for React developers
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blink-hub",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "A Dynamic Event Emitter library for Modern Javascript/TypeScript Applications",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "build": "tsc",
     "prepublishOnly": "tsc"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Listener } from "./types/listener";
 
 class Emitter<T extends Record<string, Callback<any[]>>> {
     private events: Partial<Record<keyof T, Set<Listener<Callback<any[]>>>>> = {};
+    private channels: Map<string, Emitter<T>> = new Map();
 
     subscribe<K extends keyof T>(name: K, callback: T[K], priority: number = 0): () => void {
         if (!this.events[name]) {
@@ -61,6 +62,13 @@ class Emitter<T extends Record<string, Callback<any[]>>> {
         }
 
         return results;
+    }
+
+    channel(name: string): Emitter<T> {
+        if (!this.channels.has(name)) {
+            this.channels.set(name, new Emitter<T>());
+        }
+        return this.channels.get(name) as Emitter<T>;
     }
 }
 

--- a/src/tests/channel.test.ts
+++ b/src/tests/channel.test.ts
@@ -1,0 +1,78 @@
+import Emitter from "../index";
+
+type MyEvents = {
+	eventName: (arg: string) => void;
+};
+
+describe('Emitter with Channels', () => {
+	let emitter: Emitter<MyEvents>;
+	let userChannel: Emitter<MyEvents>;
+	let adminChannel: Emitter<MyEvents>;
+
+	beforeEach(() => {
+		emitter = new Emitter<MyEvents>();
+		userChannel = emitter.channel('user');
+		adminChannel = emitter.channel('admin');
+	});
+
+	test('Subscribing and Emitting on the Global Emitter', () => {
+		let globalEventTriggered = false;
+
+		emitter.subscribe('eventName', (arg: string) => {
+			globalEventTriggered = true;
+			expect(arg).toBe('TestArg');
+		});
+
+		emitter.emit('eventName', 'TestArg');
+		expect(globalEventTriggered).toBe(true);
+	});
+
+	test('Subscribing and Emitting on a Channel', () => {
+		let channelEventTriggered = false;
+
+		userChannel.subscribe('eventName', (arg: string) => {
+			channelEventTriggered = true;
+			expect(arg).toBe('ChannelArg');
+		});
+
+		userChannel.emit('eventName', 'ChannelArg');
+		expect(channelEventTriggered).toBe(true);
+	});
+
+	test('Isolation Between Channels', () => {
+		let userEventTriggered = false;
+		let adminEventTriggered = false;
+
+		userChannel.subscribe('eventName', () => {
+			userEventTriggered = true;
+		});
+		adminChannel.subscribe('eventName', () => {
+			adminEventTriggered = true;
+		});
+
+		userChannel.emit('eventName', 'UserEvent');
+		expect(userEventTriggered).toBe(true);
+		expect(adminEventTriggered).toBe(false);
+	});
+
+	test('Channel Reusability', () => {
+		const firstUserChannel = emitter.channel('user');
+		const secondUserChannel = emitter.channel('user');
+
+		expect(firstUserChannel).toBe(secondUserChannel);
+	});
+
+	test('Unsubscribing from a Channel', () => {
+		let eventCount = 0;
+
+		const unsubscribe = userChannel.subscribe('eventName', () => {
+			eventCount++;
+		});
+
+		unsubscribe();
+
+		userChannel.emit('eventName', 'TestArg');
+		expect(eventCount).toBe(0);
+	});
+
+});


### PR DESCRIPTION
### Channels

This release introduces the new **`channel`** feature to the Emitter class, enabling isolated event handling through namespaced channels. This feature allows subscribers to group events into namespaces, reducing collision risks and organizing event-handling logic.

**Key Additions:**
- Added `channel` method for creating and retrieving unique **Emitter** instances.
- Ensured type safety and isolation between different event channels.
- Extended test suite to cover channel functionality and ensure robustness.

The implementation follows the proposed design and adheres to the existing Emitter interface, maintaining backward compatibility while extending functionality.

_Please refer to the updated documentation and test cases for usage examples and further details._