### PR TITLE
chore: fresh 0.1.0 start + project guide and workflow skills

### DIFF
--- a/.claude/skills/bench/SKILL.md
+++ b/.claude/skills/bench/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: bench
+description: Run emitrix performance checks — throughput benchmark and stress suite — and judge regressions against recorded baselines. Use for performance questions and before merging changes to dispatch, ListenerStore, or the middleware chain.
+---
+
+# Benchmarking emitrix
+
+1. `npm run build` (benchmark runs against `dist/`)
+2. `node benchmarks/loadTest.js` — 1M awaited emits across 4 listeners (incl. one wildcard)
+3. `npm run test:stress` — memory soak with leak bounds, seeded fuzz, concurrency storms
+
+## Baselines (2026-07, Apple-silicon dev machine, Node 22)
+
+- Benchmark loop: ~700 ms for 1M awaited emits
+- ~600 ns/emit with envelope + middleware + 4 mixed listeners (~1.6M emits/s/core)
+- Plain emit, 4 exact listeners: ~570 ns; parallel dispatch, 8 async listeners: ~840 ns
+- Subscribe+unsubscribe churn: ~300 ns with 100 standing listeners, ~1.3 µs at 1k, ~11.7 µs at 10k — linear O(n) growth is expected and accepted (emit-heavy workload trade-off)
+- 10k concurrent `waitFor` resolved by one emit: ~75 ms total
+
+## Interpreting regressions
+
+- >2x slower on the benchmark loop: look at `ListenerStore.collect` (the wildcard path concat+sort) and the middleware `reduceRight` chain first.
+- Soak-test heap growth over its 10 MB bound: something is retaining per-subscription state — check timer sets and `detachSignal` cleanup.
+- Fuzz failures print their seed — rerun is deterministic; do not shrug them off as flakes, they never are.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: release
+description: Cut an emitrix release — version bump, CHANGELOG section, tag + GitHub Release, automated npm publish via OIDC. Use when asked to release, publish, or ship a new version.
+---
+
+# Releasing emitrix
+
+Releases are release-event-driven: merging to master does nothing; publishing a GitHub Release triggers the npm publish.
+
+1. Preconditions: on `master`, clean tree, latest CI green.
+2. Bump the version: `npm version patch|minor|major --no-git-tag-version`.
+3. Add a `## [X.Y.Z] - YYYY-MM-DD` section at the top of CHANGELOG.md (below `## [Unreleased]`) describing the changes — `release.sh` extracts exactly this section as the release notes.
+4. Commit as `X.Y.Z` (version + lockfile + changelog) and push master.
+5. Run `./scripts/release.sh` — it tags `vX.Y.Z`, pushes the tag, and publishes a GitHub Release, which fires the `Publish to npm` workflow (test job → OIDC publish).
+6. Verify:
+   - `gh run watch $(gh run list --workflow=npm-publish.yml --limit 1 --json databaseId -q '.[0].databaseId') --exit-status`
+   - `curl -s https://registry.npmjs.org/emitrix` and confirm the new version is in `versions`. Do NOT trust local `npm view` for fresh releases — the safe-chain guard hides packages/versions younger than its minimum age.
+
+Rules:
+- The release tag must exactly match package.json (`v1.2.3` ↔ `1.2.3`) — the workflow enforces this and fails otherwise.
+- Never publish from a local machine and never introduce npm token secrets; auth is OIDC trusted publishing bound to this repo + `npm-publish.yml`.
+- If the publish job fails with ENEEDAUTH or 404, the trusted publisher config on npmjs.com (emitrix → Settings) no longer matches the repo or workflow filename — fix it there, not in CI.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: verify
+description: End-to-end verification for emitrix changes — unit tests, stress suite, TS7 build, and a dist smoke test. Run before committing any non-trivial change.
+---
+
+# Verifying emitrix
+
+Run all four; every one must pass:
+
+1. `npm test` — unit suite
+2. `npm run test:stress` — soak/fuzz/storm suite (mandatory for dispatch, cancellation, or ListenerStore changes; cheap enough to always run)
+3. `npm run build` — TS7 compile to dist/
+4. Dist smoke test (exercises the actual published artifact, not just src):
+
+```bash
+node -e "
+const { Emitter } = require('./dist');
+const bus = new Emitter();
+bus.on('smoke.test', (p, e) => { if (!e.id || !e.correlationId) throw new Error('envelope broken'); });
+bus.emit('smoke.test', { ok: true }).then(r => {
+  if (!r.ok || r.outcomes.length !== 1) throw new Error('dispatch broken');
+  console.log('dist smoke: OK');
+});
+"
+```
+
+If tests pass but the smoke test fails, the build output diverged from src expectations (tsconfig or export-shape issue) — check `dist/index.d.ts` exports before anything else.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,181 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.1] - 2026-07-16
+## [0.1.0] - 2026-07-16
 
-### Changed
-- No code changes. Validates the fully automated release pipeline: GitHub Release → CI tests → npm publish via OIDC trusted publishing. The 1.x-era package name has been unpublished from npm; `emitrix` is the sole identity.
-
-## [2.0.0] - 2026-07-16
-
-Complete rewrite as an async-first, in-process event bus for backend (DDD/EDA) use. **No backward compatibility with 1.x.**
-
-**The package was renamed to `emitrix`** (repository: valehasadli/emitrix). 1.x releases remain published on npm under the previous name and are deprecated.
-
-### Breaking
-- **Event maps now declare payload types, not callback signatures** — `type Events = { 'user.registered': { userId: string } }`. Handlers receive `(payload, envelope)` instead of positional arguments.
-- **`emit` is async** — it returns `Promise<EmitResult>` and awaits every handler (sync or async). Handler return values are no longer collected.
-- **`subscribe`/`subscribeList`/`subscribeWithDelay` removed** — use `on(pattern, handler, options)` with `priority`, `delay`, and `signal` options.
-- **Errors are no longer mixed into a results array** — under the default `aggregate` policy they are collected in `EmitResult.errors` and reported to `onError` hooks; under `fail-fast` emit rejects with `EmitError`.
-- **Default export is now the named `Emitter` class**; the package exposes named exports for all types and errors.
-- **Requires Node.js >= 20** (any modern browser still works).
+Initial public release of **Emitrix** — an async-first, type-safe in-process event bus for Node.js backends (DDD/EDA moduliths). Zero runtime dependencies; no Node-specific APIs, so it also runs in browsers, Deno, Bun, and React Native.
 
 ### Added
-- **Event envelopes** — every event carries `id`, `timestamp`, `correlationId`, `causationId`, and mutable `metadata` for tracing and outbox integration.
-- **Error policies** — `aggregate` (default) or `fail-fast`, configurable per emitter and per emit.
+
+- **Typed event maps** — event names map to payload types; handlers receive `(payload, envelope)` and may be async. `emit` awaits every handler and returns a `Promise<EmitResult>`; async rejections are always captured and can never become unhandled promise rejections.
+- **Event envelopes** — every event carries `id`, `timestamp`, `correlationId`, `causationId`, and mutable `metadata` for tracing, audit, and outbox integration.
+- **Error policies** — `aggregate` (default: every handler runs, failures collected in `EmitResult.errors` and reported to `onError` hooks) or `fail-fast` (rejects with `EmitError`), configurable per emitter and per emit.
 - **Dispatch modes** — `sequential` (default, priority-ordered) or `parallel`, configurable per emitter and per emit.
 - **Wildcard subscriptions** — `'user.*'` prefix patterns and `'*'` catch-all, fully typed via template-literal types.
 - **Middleware pipeline** — `use((event, next) => ...)` wraps every dispatch for tracing, logging, metrics, or enrichment; may short-circuit.
-- **`onError` hooks** — centralized handler-failure reporting, including failures of delayed handlers.
-- **`waitFor(pattern, { timeoutMs, signal, filter })`** — promise-based one-shot subscription with `TimeoutError`/`AbortError` rejections.
-- **`AbortSignal` support** on subscriptions.
-- **Cancellable delayed listeners** — unsubscribe (or abort) now cancels pending `delay` timers (fixes 1.x firing after unsubscribe).
-- **Leak warnings via `onWarning` hook** instead of hardcoded `console.warn`.
-- **`dispose()`** for full teardown of listeners, middleware, hooks, and channels.
+- **`waitFor(pattern, { timeoutMs, signal, filter })`** — promise-based one-shot subscription with `TimeoutError` / `AbortError` rejections.
+- **`AbortSignal` support** on subscriptions; **delayed listeners** whose pending timers are cancelled by unsubscribe/abort.
+- **Channels** — isolated scopes inheriting the parent configuration.
+- **Introspection and memory management** — `listenerCount`, `eventNames`, `removeAllListeners`, `dispose()`, and leak warnings via an `onWarning` hook.
 
-### Changed
-- Tooling upgraded: TypeScript 7 (native compiler), Jest 30, Babel 8, ES2022 output (~4.5x faster emits than the 1.x ES2016 build).
-- CI modernized: PR tests run on a Node 20/22/24/26 matrix; publish and Sonar jobs run on Node 24 LTS; actions upgraded (checkout/setup-node v7, action-gh-release v3); the deprecated sonarcloud-github-action replaced with SonarSource/sonarqube-scan-action v8.
-- Added a stress suite (`npm run test:stress`, also in CI): memory-soak with leak bounds, seeded fuzz testing against a reference model, and concurrency storms (parallel emits, error floods, mass delayed-timer cancellation).
-- **License changed from Apache-2.0 to MIT.**
-- Added community health files: CODE_OF_CONDUCT.md (Contributor Covenant 2.1), CONTRIBUTING.md, issue templates, and a pull request template.
+### Tooling
 
-## [1.2.1] - 2026-02-03
-
-### Changed
-- **Dependencies** - Updated internal dependencies for improved security and performance
-
-## [1.2.0] - 2025-10-31
-
-### Documentation
-- **Quick Start Examples** - Added complete minimal working apps for React, Vue, and Svelte
-- **Framework Use Cases** - Added 11 production-ready examples across all frameworks
-  - React: Toast notifications, real-time chat, analytics
-  - Vue: Global state, shopping cart
-  - Svelte: Loading state, form validation
-  - Node.js: Event bus, monitoring, database streams, job queues
-- **Integration Guides** - Added framework-specific best practices
-  - React hooks and cleanup patterns
-  - Vue composables and plugins
-  - Svelte stores and lifecycle management
-- **Enhanced FAQ** - Comprehensive answers with code examples
-- **Comparison Tables** - Emitrix vs EventEmitter feature matrix
-- **Professional Formatting** - Added badges, emojis, better structure
-
-### Improved
-- Better developer onboarding experience
-- Clear framework-specific documentation
-- Production-ready code examples
-
-## [1.1.0] - 2025-10-31
-
-### Added
-- **Memory Management System** - Enterprise-grade memory leak detection and prevention
-  - `setMaxListeners(n)` - Set maximum listeners per event (default: 10)
-  - `getMaxListeners()` - Get current maximum listener limit
-  - `listenerCount(event)` - Count listeners for specific events
-  - `getEventNames()` - List all events with active listeners
-  - `getListeners(event)` - Retrieve all listener functions for an event
-  - `removeAllListeners(event?)` - Remove listeners for specific or all events
-  - Automatic memory leak warnings when listener limit exceeded
-  - Node.js EventEmitter API compatibility
-
-### Changed
-- Enhanced `PriorityQueue` with `size()` method for listener tracking
-- Improved event registry with listener introspection capabilities
-
-### Documentation
-- Added comprehensive Memory Management section to README
-- Added best practices for listener cleanup
-- Added memory leak detection examples
-
-## [1.0.4] - 2025-10-27
-
-### Internal
-- Upgraded to modern GitHub release action for better automation
-
-### Added
-- Automated GitHub releases workflow triggered by version tags
-- Helper script `scripts/release.sh` for simplified release process
-- npm provenance support for supply chain security
-
-## [1.0.3] - 2025-10-27
-
-### Added
-- Automated GitHub releases workflow triggered by version tags
-- Helper script `scripts/release.sh` for simplified release process
-- npm provenance support for supply chain security
-
-### Changed
-- npm publish workflow now triggers on git tags (v*) instead of master branch pushes
-- GitHub releases are now auto-created with changelog content extracted from CHANGELOG.md
-- Improved release workflow with automated testing, building, and publishing
-
-## [1.0.2] - 2025-10-27
-
-### Fixed
-- Fixed README.md not appearing on npm package page
-- Removed README.md from .npmignore
-- Added README.md, CHANGELOG.md, and LICENSE to package.json files array
-- Removed unnecessary GitHub Actions workflows (greetings, labeler, stale)
-
-## [1.0.1] - 2025-10-27
-
-### Security
-- Updated dev dependencies to resolve security vulnerabilities
-- Fixed 5 vulnerabilities (1 high, 3 moderate, 1 low) in dev dependencies
-  - @babel/helpers (<7.26.10)
-  - @babel/runtime (<7.26.10)
-  - brace-expansion (1.0.0 - 1.1.11)
-  - cross-spawn (7.0.0 - 7.0.4)
-  - micromatch (<4.0.8)
-
-### Changed
-- All tests continue to pass (55/55 tests, 100% coverage)
-- Build process verified and working
-
-## [1.0.0] - 2025-10-27
-
-### Changed
-- **BREAKING**: Changed license from GPL-3.0-or-later to Apache-2.0 for enterprise compatibility
-- Migrated from yarn to npm for package management
-- Updated GitHub Actions workflows to use npm instead of yarn
-- Upgraded GitHub Actions to v4 (setup-node@v4, checkout@v4)
-- Disabled SonarCloud scans on pull requests (only runs on master branch)
-
-### Removed
-- Removed yarn.lock file
-- Removed all yarn-related references from configuration files
-
-### Fixed
-- Fixed GitHub Actions cache errors by switching from yarn to npm cache
-- Fixed YAML syntax errors in npm-publish workflow
-
-## [0.5.0.1] - Previous Development Version
-
-### Added
-- Type-safe event emitter with TypeScript support
-- Priority-based event handling
-- Channel-based event handling for isolated event scopes
-- `once()` method for single-execution listeners
-- `subscribeWithDelay()` for delayed event handling
-- `subscribeList()` for bulk event subscriptions
-- Comprehensive error handling and resilience
-- 100% test coverage (55 tests)
-- Zero runtime dependencies
-
-### Features
-- Full TypeScript support with strict typing
-- Event subscription with priority queues
-- Multiple event channels for modular architecture
-- Automatic unsubscribe functionality
-- Support for async callbacks
-- Detailed documentation and examples
-
-[unreleased]: https://github.com/valehasadli/emitrix/compare/v1.2.0...HEAD
-[1.2.0]: https://github.com/valehasadli/emitrix/compare/v1.1.0...v1.2.0
-[1.0.3]: https://github.com/valehasadli/emitrix/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/valehasadli/emitrix/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/valehasadli/emitrix/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/valehasadli/emitrix/compare/v0.5.0.1...v1.0.0
-[0.5.0.1]: https://github.com/valehasadli/emitrix/releases/tag/v0.5.0.1
+- TypeScript 7 (native compiler), ES2022 output, Jest 30, Babel 8; requires Node.js >= 20 (any modern browser works).
+- Test suite (~95% coverage) plus a stress suite (`npm run test:stress`): memory soak with leak bounds, seeded fuzz against a reference model, and concurrency storms.
+- CI: PR test matrix on Node 20/22/24/26, SonarCloud quality gate on every PR, and release-driven npm publishing via OIDC trusted publishing (no tokens).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# Emitrix — Project Guide
+
+Async-first, type-safe **in-process event bus** for Node.js backends — domain events in DDD/EDA moduliths, module-to-module signaling. Zero runtime dependencies and no Node-specific APIs (only `Promise`, `setTimeout`, `AbortSignal`), so it also runs in browsers, Deno, Bun, and React Native.
+
+It is deliberately NOT a message broker: events are in-memory only. Durability belongs to an outbox + broker (Kafka/NATS/Redis Streams) composed on top — never reimplement that here.
+
+## Commands
+
+- `npm test` — unit suite (tests/core, tests/channels); stress tests excluded
+- `npm run test:stress` — soak / seeded-fuzz / concurrency-storm suite (tests/stress)
+- `npm run test:coverage` — unit suite with coverage
+- `npm run build` — TypeScript 7 → `dist/` (CommonJS, ES2022 target)
+- `node benchmarks/loadTest.js` — throughput sanity check (requires a build)
+
+## Architecture
+
+- `src/lib/types.ts` — the public type surface: `EventMap` (event name → payload type), `EventEnvelope` (id, timestamp, correlationId, causationId, metadata), handler/options/result types, `Middleware`, `ErrorHook`
+- `src/lib/errors.ts` — `EmitError` (fail-fast), `TimeoutError` / `AbortError` (waitFor)
+- `src/lib/ListenerStore.ts` — priority-sorted listener buckets per exact event name plus prefix-wildcard entries (`'user.*'`, `'*'`); O(n) insert/remove by design (emit-heavy workload)
+- `src/lib/Emitter.ts` — everything else: envelope creation, middleware chain, sequential/parallel dispatch, error policies (`aggregate` | `fail-fast`), `once`/`waitFor`, delayed listeners with timer cancellation, channels, leak warnings, `dispose()`
+
+Handlers receive `(payload, envelope)` and may be async; `emit` awaits them all and returns an `EmitResult` (outcomes, errors, ok).
+
+## Invariants — do not break these
+
+1. **Zero runtime dependencies.** No exceptions, including "tiny" ones.
+2. **No Node-only APIs.** The library must stay isomorphic.
+3. **Async rejections never escape.** Every handler invocation is wrapped; a handler failure must land in an `EmitResult` and/or `onError` hook, never as an unhandled rejection.
+4. **Unsubscribe cancels pending delayed timers.** The 1.x fire-after-unsubscribe bug must never return.
+5. **`once` listeners detach before invocation** so re-entrant emits cannot double-fire them.
+6. **Handlers do not return values to the emitter.** The bus is one-way; request/response goes through `waitFor` or a separate query path.
+
+## Style
+
+- Tabs for indentation; explicit return types on functions.
+- Comments only for non-obvious constraints (see the createId fallback for the tone).
+- Avoid `Math.random()` anywhere — SonarCloud S2245 fails the quality gate on it.
+
+## Testing expectations
+
+- Any behavioral change needs a test in `tests/core` or `tests/channels`.
+- Changes to dispatch, cancellation, or `ListenerStore` must also pass `npm run test:stress` — the fuzz suite replays seeded random op sequences against a reference model and will catch listener-accounting regressions the unit tests miss.
+
+## Release process
+
+Merging to master does NOT release. Releases are explicit:
+
+1. Bump `version` in package.json (`npm version patch|minor|major --no-git-tag-version`).
+2. Add a `## [X.Y.Z] - YYYY-MM-DD` section to CHANGELOG.md — release notes are extracted from it verbatim.
+3. Commit as `X.Y.Z`, push master.
+4. Run `./scripts/release.sh` — tags `vX.Y.Z` and publishes a GitHub Release, which triggers CI: test → npm publish via **OIDC trusted publishing** (no tokens exist anywhere; never add one).
+
+## CI map
+
+- `test-on-pr.yml` — PRs to master: Node 20/22/24/26 matrix running unit + stress + build
+- `sonarqube.yml` — master pushes and same-repo PRs: SonarCloud quality gate; PR conversations (including bot findings) must be resolved before merge
+- `npm-publish.yml` — on GitHub Release published: test job, then OIDC publish (trusted publisher = this repo + this workflow filename; release tag must equal package.json version)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,12 @@
 
 ## Supported Versions
 
-Only the latest major version receives security fixes.
+Only the latest minor version receives security fixes.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 2.x     | :white_check_mark: |
-| < 2.0   | :x:                |
-
-Note that 2.0 was a breaking rewrite — 1.x users should consult the
-[CHANGELOG](CHANGELOG.md) before upgrading.
+| 0.1.x   | :white_check_mark: |
+| < 0.1   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emitrix",
-  "version": "2.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emitrix",
-      "version": "2.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emitrix",
-  "version": "2.0.1",
+  "version": "0.1.0",
   "description": "Async-first, type-safe in-process event bus for Node.js backends: awaited handlers, error policies, middleware, wildcards, and correlation metadata. Zero dependencies, runs in any JS runtime.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Two things: a clean versioning restart, and a project guide with repeatable workflow skills.

### Fresh 0.1.0 start
- **Version reset 2.0.1 → 0.1.0.** emitrix is a brand-new npm package; a 2.x version implied a history the package doesn't have. All git tags (25) and GitHub releases (15) from the previous era are deleted — the repo history remains, but versioning starts over.
- **CHANGELOG restarted** — single `[0.1.0]` section describing the initial public release.
- **SECURITY.md** updated to support the 0.1.x line.
- After this releases as 0.1.0 on npm, the interim 2.0.0/2.0.1 versions will be unpublished (both < 72h old, so npm policy allows it).

### Project guide and workflow skills
- **CLAUDE.md** — the project guide: commands, architecture per file, the six invariants that must never break (zero deps, isomorphic, no escaped rejections, timer cancellation on unsubscribe, once-detach-before-invoke, one-way bus), style rules, testing expectations, release process, CI map.
- **Workflow skills** (`.claude/skills/`):
  - `release` — cut a release end-to-end: bump, CHANGELOG section, `release.sh`, verify on the registry (including the local safe-chain caveat).
  - `bench` — run benchmark + stress suite with recorded 2026-07 baselines and a regression triage guide.
  - `verify` — the full pre-commit gate: unit, stress, build, dist smoke test.

## Test plan
- [x] `npm test` — 55/55 passing
- [ ] CI matrix green (Node 20/22/24/26) + SonarCloud quality gate

## After merge
`./scripts/release.sh` publishes v0.1.0 (GitHub Release → CI test → OIDC npm publish — the flow validated end-to-end by the interim releases). Then unpublish the interim 2.0.x versions.